### PR TITLE
Pin tower crates to tenx-tech forks with specific revisions

### DIFF
--- a/tower-add-origin/Cargo.toml
+++ b/tower-add-origin/Cargo.toml
@@ -6,7 +6,11 @@ authors = ["Carl Lerche <me@carllerche.com>"]
 [dependencies]
 futures = "0.1"
 http = "0.1"
-tower-service = { git = "https://github.com/tower-rs/tower" }
 
-[dev-dependencies]
-tower-mock = { git = "https://github.com/tower-rs/tower" }
+[dependencies.tower-service]
+git = "https://github.com/tower-rs/tower"
+rev = "20fb04e"
+
+[dev-dependencies.tower-mock]
+git = "https://github.com/tower-rs/tower"
+rev = "20fb04e"


### PR DESCRIPTION
### Changed

* Update `Cargo.toml` for `tower-add-origin`, which in turn affects local `tower-http`.